### PR TITLE
Add legal disclaimers, /terms page, and GPL compliance NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,7 +29,6 @@ Third-Party Components
 This software includes the following third-party components:
 
 1. yt-dlp
-   - Copyright (c) 2023-2026 yt-dlp contributors
    - License: Unlicense (public domain)
    - URL: https://github.com/yt-dlp/yt-dlp
 
@@ -39,7 +38,7 @@ This software includes the following third-party components:
    - URL: https://github.com/tiangolo/fastapi
 
 3. SQLAlchemy
-   - Copyright (c) 2005-2026 SQLAlchemy authors
+   - Copyright (c) 2007-2026 SQLAlchemy authors
    - License: MIT
    - URL: https://github.com/sqlalchemy/sqlalchemy
 
@@ -55,8 +54,8 @@ This software includes the following third-party components:
 
 6. HTMX
    - Copyright (c) 2023-2026 Big Sky Software
-   - License: Apache 2.0
-   - URL: https://github.com/htmx/htmx
+   - License: 0BSD
+   - URL: https://github.com/bigskysoftware/htmx
 
 7. Tailwind CSS
    - Copyright (c) 2023-2026 Tailwind Labs

--- a/NOTICE
+++ b/NOTICE
@@ -22,7 +22,6 @@ Third-Party Components
 This software includes the following third-party components:
 
 1. yt-dlp
-   - Copyright (c) 2023 yt-dlp contributors
    - License: Unlicense (public domain)
    - URL: https://github.com/yt-dlp/yt-dlp
 
@@ -32,7 +31,7 @@ This software includes the following third-party components:
    - URL: https://github.com/tiangolo/fastapi
 
 3. SQLAlchemy
-   - Copyright (c) 2005-2023 SQLAlchemy authors
+   - Copyright (c) 2007-2026 SQLAlchemy authors
    - License: MIT
    - URL: https://github.com/sqlalchemy/sqlalchemy
 
@@ -48,8 +47,8 @@ This software includes the following third-party components:
 
 6. HTMX
    - Copyright (c) 2023 Big Sky Software
-   - License: Apache 2.0
-   - URL: https://github.com/htmx/htmx
+   - License: 0BSD
+   - URL: https://github.com/bigskysoftware/htmx
 
 7. Tailwind CSS
    - Copyright (c) Tailwind Labs

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,81 @@
+NOTICE
+======
+
+Vooglaadija
+Copyright (c) 2024-2026 Vooglaadija Contributors
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+
+Warranty Disclaimer and Liability Limitation
+--------------------------------------------
+This software is provided AS IS, AS AVAILABLE, with NO WARRANTIES.
+Per GPLv3 Section 15, this program is provided without warranty of any kind.
+Per GPLv3 Section 16, no liability is accepted for any damages arising
+from the use of this software.
+
+Third-Party Components
+----------------------
+
+This software includes the following third-party components:
+
+1. yt-dlp
+   - License: Unlicense (public domain)
+   - URL: https://github.com/yt-dlp/yt-dlp
+
+2. FastAPI
+   - Copyright (c) 2018-2026 Sebastián Ramírez
+   - License: MIT
+   - URL: https://github.com/tiangolo/fastapi
+
+3. SQLAlchemy
+   - Copyright (c) 2007-2026 SQLAlchemy authors
+   - License: MIT
+   - URL: https://github.com/sqlalchemy/sqlalchemy
+
+4. Pydantic
+   - Copyright (c) 2018-2026 Samuel Colvin and contributors
+   - License: MIT
+   - URL: https://github.com/pydantic/pydantic
+
+5. Redis (python)
+   - Copyright (c) 2023-2026 Redis contributors
+   - License: MIT
+   - URL: https://github.com/redis/redis-py
+
+6. HTMX
+   - Copyright (c) 2023-2026 Big Sky Software
+   - License: 0BSD
+   - URL: https://github.com/bigskysoftware/htmx
+
+7. Tailwind CSS
+   - Copyright (c) 2023-2026 Tailwind Labs
+   - License: MIT
+   - URL: https://github.com/tailwindlabs/tailwindcss
+
+For full license texts of third-party components, please refer to their
+respective repositories.
+
+Nature of Vooglaadija
+---------------------
+Vooglaadija does not host, re-upload, or redistribute any copyrighted content.
+It is a passive download tool — the user initiates all downloads. The service
+operator does not select, modify, or control the content being downloaded.
+
+This tool has substantial non-infringing uses including:
+- Downloading content you own or have created
+- Downloading content with explicit permission from the copyright holder
+- Downloading Creative Commons or public domain content
+- Archival purposes with creator's consent
+
+Users are solely responsible for ensuring they have the right to download
+any content before using this tool. See Terms of Service for details.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,76 @@
+NOTICE
+======
+
+Vooglaadija
+Copyright (c) 2024-2026 Vooglaadija Contributors
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+
+Third-Party Components
+---------------------
+
+This software includes the following third-party components:
+
+1. yt-dlp
+   - Copyright (c) 2023 yt-dlp contributors
+   - License: Unlicense (public domain)
+   - URL: https://github.com/yt-dlp/yt-dlp
+
+2. FastAPI
+   - Copyright (c) 2018 Sebastián Ramírez
+   - License: MIT
+   - URL: https://github.com/tiangolo/fastapi
+
+3. SQLAlchemy
+   - Copyright (c) 2005-2023 SQLAlchemy authors
+   - License: MIT
+   - URL: https://github.com/sqlalchemy/sqlalchemy
+
+4. Pydantic
+   - Copyright (c) 2018 Samuel Colvin
+   - License: MIT
+   - URL: https://github.com/pydantic/pydantic
+
+5. Redis (python)
+   - Copyright (c) Redis contributors
+   - License: MIT
+   - URL: https://github.com/redis/redis-py
+
+6. HTMX
+   - Copyright (c) 2023 Big Sky Software
+   - License: Apache 2.0
+   - URL: https://github.com/htmx/htmx
+
+7. Tailwind CSS
+   - Copyright (c) Tailwind Labs
+   - License: MIT
+   - URL: https://github.com/tailwindlabs/tailwindcss
+
+For full license texts of third-party components, please refer to their
+respective repositories.
+
+Vooglaadija does not host, re-upload, or redistribute any copyrighted content.
+Users are solely responsible for ensuring they have the right to download
+any content before using this tool. See TERMS OF SERVICE for details.
+
+DMCA §1201 Notice
+-----------------
+This software is a passive download tool. It does not select, modify, or
+control the content being downloaded. The user initiates all downloads.
+This tool has substantial non-infringing uses including:
+- Downloading content you own or have created
+- Downloading content with explicit permission from the copyright holder
+- Downloading Creative Commons or public domain content
+- Archival purposes with creator's consent
+
+Users must comply with applicable laws and platform terms of service.

--- a/NOTICE
+++ b/NOTICE
@@ -16,61 +16,67 @@ FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 
+Warranty Disclaimer and Liability Limitation
+--------------------------------------------
+This software is provided AS IS, AS AVAILABLE, with NO WARRANTIES.
+Per GPLv3 Section 15, this program is provided without warranty of any kind.
+Per GPLv3 Section 16, no liability is accepted for any damages arising
+from the use of this software.
+
 Third-Party Components
----------------------
+----------------------
 
 This software includes the following third-party components:
 
 1. yt-dlp
-   - Copyright (c) 2023 yt-dlp contributors
+   - Copyright (c) 2023-2026 yt-dlp contributors
    - License: Unlicense (public domain)
    - URL: https://github.com/yt-dlp/yt-dlp
 
 2. FastAPI
-   - Copyright (c) 2018 Sebastián Ramírez
+   - Copyright (c) 2018-2026 Sebastián Ramírez
    - License: MIT
    - URL: https://github.com/tiangolo/fastapi
 
 3. SQLAlchemy
-   - Copyright (c) 2005-2023 SQLAlchemy authors
+   - Copyright (c) 2005-2026 SQLAlchemy authors
    - License: MIT
    - URL: https://github.com/sqlalchemy/sqlalchemy
 
 4. Pydantic
-   - Copyright (c) 2018 Samuel Colvin
+   - Copyright (c) 2018-2026 Samuel Colvin and contributors
    - License: MIT
    - URL: https://github.com/pydantic/pydantic
 
 5. Redis (python)
-   - Copyright (c) Redis contributors
+   - Copyright (c) 2023-2026 Redis contributors
    - License: MIT
    - URL: https://github.com/redis/redis-py
 
 6. HTMX
-   - Copyright (c) 2023 Big Sky Software
+   - Copyright (c) 2023-2026 Big Sky Software
    - License: Apache 2.0
    - URL: https://github.com/htmx/htmx
 
 7. Tailwind CSS
-   - Copyright (c) Tailwind Labs
+   - Copyright (c) 2023-2026 Tailwind Labs
    - License: MIT
    - URL: https://github.com/tailwindlabs/tailwindcss
 
 For full license texts of third-party components, please refer to their
 respective repositories.
 
+Nature of Vooglaadija
+---------------------
 Vooglaadija does not host, re-upload, or redistribute any copyrighted content.
-Users are solely responsible for ensuring they have the right to download
-any content before using this tool. See TERMS OF SERVICE for details.
+It is a passive download tool — the user initiates all downloads. The service
+operator does not select, modify, or control the content being downloaded.
 
-DMCA §1201 Notice
------------------
-This software is a passive download tool. It does not select, modify, or
-control the content being downloaded. The user initiates all downloads.
 This tool has substantial non-infringing uses including:
 - Downloading content you own or have created
 - Downloading content with explicit permission from the copyright holder
 - Downloading Creative Commons or public domain content
 - Archival purposes with creator's consent
 
-Users must comply with applicable laws and platform terms of service.
+Users are solely responsible for ensuring they have the right to download
+any content before using this tool. See Terms of Service for details.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ Vooglaadija is an async REST API for extracting media from video URLs. It uses [
 
 The system includes JWT authentication, CSRF protection, rate limiting, structured logging, Prometheus metrics, OpenTelemetry tracing, and Sentry error tracking. A server-rendered web UI built with HTMX and Tailwind CSS provides job management with real-time status updates via Server-Sent Events.
 
+### Legitimate Use Cases
+
+Vooglaadija is a tool. Examples of legitimate uses include:
+
+- Downloading your own YouTube content
+- Archival or backup of content you have created or have explicit permission to download
+- Downloading Creative Commons or public domain content
+- Offline access to content you are authorized to view
+
+### Legal Disclaimer
+
+**You are responsible for ensuring you have the right to download any content before using Vooglaadija.** Downloading copyrighted content without authorization may violate YouTube's Terms of Service and applicable copyright law, including the DMCA §1201 anti-circumvention provisions in the US.
+
+Vooglaadija is open-source software provided under GPLv3. The operators of this service do not endorse or encourage copyright infringement. This tool has substantial non-infringing uses and is designed for lawful purposes only. Users should consult qualified legal counsel if unsure about the legality of their use case.
+
+See the [Terms of Service](/terms) for full details.
+
 ---
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Vooglaadija is a tool. Examples of legitimate uses include:
 
 Vooglaadija is open-source software provided under GPLv3. The operators of this service do not endorse or encourage copyright infringement. This tool has substantial non-infringing uses and is designed for lawful purposes only. Users should consult qualified legal counsel if unsure about the legality of their use case.
 
-See the [Terms of Service](/terms) for full details.
+See the [Terms of Service](/web/terms) for full details.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ Prometheus metrics, OpenTelemetry tracing, and Sentry error tracking. A server-r
 with HTMX and Tailwind CSS provides job management with real-time status updates via Server-Sent
 Events.
 
+### Legitimate Use Cases
+
+Vooglaadija is a tool. Examples of legitimate uses include:
+
+- Downloading your own YouTube content
+- Archival or backup of content you have created or have explicit permission to download
+- Downloading Creative Commons or public domain content
+- Offline access to content you are authorized to view
+
+### Legal Disclaimer
+
+**You are responsible for ensuring you have the right to download any content before using Vooglaadija.** Downloading copyrighted content without authorization may violate YouTube's Terms of Service and applicable copyright law, including the DMCA §1201 anti-circumvention provisions in the US.
+
+Vooglaadija is open-source software provided under GPLv3. The operators of this service do not endorse or encourage copyright infringement. This tool has substantial non-infringing uses and is designed for lawful purposes only. Users should consult qualified legal counsel if unsure about the legality of their use case.
+
+See the [Terms of Service](/web/terms) for full details.
+
 ---
 
 ## Features

--- a/app/api/routes/web.py
+++ b/app/api/routes/web.py
@@ -416,6 +416,19 @@ async def logout(request: Request):
     return redirect
 
 
+@router.get("/terms")
+async def terms_page(request: Request):
+    """Render terms of service page with copyright disclaimers and lawful-use requirements."""
+    token = get_csrf_token(request)
+    response = templates.TemplateResponse(
+        request,
+        "terms.html",
+        get_template_context(request, csrf_token=token),
+    )
+    set_csrf_token_cookie(response, token)
+    return response
+
+
 # ========================
 # PROTECTED ROUTES
 # ========================

--- a/app/api/routes/web.py
+++ b/app/api/routes/web.py
@@ -419,14 +419,11 @@ async def logout(request: Request):
 @router.get("/terms")
 async def terms_page(request: Request):
     """Render terms of service page with copyright disclaimers and lawful-use requirements."""
-    token = get_csrf_token(request)
-    response = templates.TemplateResponse(
+    return templates.TemplateResponse(
         request,
         "terms.html",
-        get_template_context(request, csrf_token=token),
+        get_template_context(request),
     )
-    set_csrf_token_cookie(response, token)
-    return response
 
 
 # ========================

--- a/app/api/routes/web.py
+++ b/app/api/routes/web.py
@@ -422,7 +422,7 @@ async def terms_page(request: Request):
     return templates.TemplateResponse(
         request,
         "terms.html",
-        get_template_context(request),
+        get_template_context(request, last_updated="April 26, 2026"),
     )
 
 

--- a/app/api/routes/web.py
+++ b/app/api/routes/web.py
@@ -423,7 +423,7 @@ async def terms_page(request: Request):
     response = templates.TemplateResponse(
         request,
         "terms.html",
-        get_template_context(request, csrf_token=token),
+        get_template_context(request, csrf_token=token, last_updated="April 26, 2026"),
     )
     set_csrf_token_cookie(response, token)
     return response

--- a/app/api/routes/web/__init__.py
+++ b/app/api/routes/web/__init__.py
@@ -2,7 +2,13 @@
 
 from fastapi import APIRouter
 
-from app.api.routes.web import web_auth, web_dashboard, web_downloads, web_settings
+from app.api.routes.web import (
+    web_auth,
+    web_dashboard,
+    web_downloads,
+    web_settings,
+    web_terms,
+)
 from app.api.routes.web.web_helpers import (  # noqa: F401
     _change_password_response,
     _demo_user_or_raise,
@@ -33,3 +39,4 @@ router.include_router(web_auth.router)
 router.include_router(web_downloads.router)
 router.include_router(web_dashboard.router)
 router.include_router(web_settings.router)
+router.include_router(web_terms.router)

--- a/app/api/routes/web/web_terms.py
+++ b/app/api/routes/web/web_terms.py
@@ -1,0 +1,25 @@
+"""Terms of Service web page route."""
+
+from fastapi import APIRouter, Request
+
+from app.api.routes.web.web_helpers import (
+    get_csrf_token,
+    get_template_context,
+    set_csrf_token_cookie,
+    templates,
+)
+
+router = APIRouter(tags=["web"])
+
+
+@router.get("/terms")
+async def terms_page(request: Request):
+    """Render terms of service page with copyright disclaimers and lawful-use requirements."""
+    token = get_csrf_token(request)
+    response = templates.TemplateResponse(
+        request,
+        "terms.html",
+        get_template_context(request, csrf_token=token, last_updated="April 26, 2026"),
+    )
+    set_csrf_token_cookie(response, token)
+    return response

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -144,12 +144,6 @@
                 class="text-sm text-gray-600 hover:text-amber-400 transition-colors duration-300 font-body"
                 >Terms</a
               >
-              <span class="text-gray-800" aria-hidden="true">|</span>
-              <a
-                href="/privacy"
-                class="text-sm text-gray-600 hover:text-amber-400 transition-colors duration-300 font-body"
-                >Privacy</a
-              >
             </div>
           </div>
         </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -140,21 +140,15 @@
             </div>
             <div class="flex gap-8">
               <a
-                href="/privacy"
-                class="text-sm text-gray-600 hover:text-amber-400 transition-colors duration-300 font-body"
-                >Privacy</a
-              >
-              <span class="text-gray-800" aria-hidden="true">|</span>
-              <a
-                href="/terms"
+                href="/web/terms"
                 class="text-sm text-gray-600 hover:text-amber-400 transition-colors duration-300 font-body"
                 >Terms</a
               >
               <span class="text-gray-800" aria-hidden="true">|</span>
               <a
-                href="/contact"
+                href="/privacy"
                 class="text-sm text-gray-600 hover:text-amber-400 transition-colors duration-300 font-body"
-                >Contact</a
+                >Privacy</a
               >
             </div>
           </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -117,6 +117,11 @@
             <div class="flex items-center gap-6">
               <span class="text-sm text-gray-400 font-body">Open source &mdash; GPLv3</span>
               <a href="https://github.com/tomkabel/team21-vooglaadija" class="text-sm text-gray-400 hover:text-amber-400 focus-visible:text-amber-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-900 rounded-md transition-colors duration-300 font-body" target="_blank" rel="noopener noreferrer">GitHub</a>
+              <a
+                href="/web/terms"
+                class="text-sm text-gray-600 hover:text-amber-400 transition-colors duration-300 font-body"
+                >Terms</a
+              >
             </div>
           </div>
         </div>

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -18,7 +18,7 @@
                     Terms of Service
                 </h1>
                 <p class="mt-3 text-gray-500 font-body">
-                    Last updated: {{ current_year }}
+                    Last updated: April 2026
                 </p>
             </div>
 
@@ -51,7 +51,7 @@
                     </h2>
                     <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
                         <p>
-                            By accessing or using Vooglaadija, you agree to be bound by these Terms of Service. If you do not agree to these terms, do not use this service.
+                            By accessing or using Vooglaadija, you acknowledge that you have read, understood, and agree to be bound by these Terms of Service. If you do not agree to these terms, do not use this service.
                         </p>
                     </div>
                 </section>
@@ -104,6 +104,9 @@
                         <p>
                             To the maximum extent permitted by law, the operators of this service shall not be liable for any damages arising from the use of Vooglaadija, including but not limited to direct, indirect, incidental, special, or consequential damages.
                         </p>
+                        <p>
+                            As permitted by GPLv3 Sections 15 and 16, this software is provided without warranty or liability of any kind for any purpose.
+                        </p>
                     </div>
                 </section>
 
@@ -119,6 +122,12 @@
                         <p>
                             If you are a rights holder and believe that this service is being used to infringe your rights, contact the service administrator. We take intellectual property rights seriously and will cooperate with legitimate takedown requests.
                         </p>
+                        <div class="bg-surface-800/50 rounded-lg p-4 mt-4">
+                            <h4 class="text-sm font-display font-semibold text-gray-300 mb-2">DMCA Designated Agent</h4>
+                            <p class="text-xs text-gray-500 font-mono">
+                                To file a DMCA takedown request, contact the service administrator at the email address associated with this service.
+                            </p>
+                        </div>
                     </div>
                 </section>
 
@@ -144,27 +153,45 @@
                     </h2>
                     <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
                         <p>
-                            These terms may be updated at any time. Continued use of the service after any changes constitutes acceptance of the updated terms.
+                            These terms may be updated at any time to reflect changes in law, service architecture, or operational requirements. Material changes will be communicated via a notice on this page and, where practicable, via the service dashboard.
+                        </p>
+                        <p>
+                            Continued use of the service after any modification constitutes acceptance of the updated terms. Users are advised to review these terms periodically.
                         </p>
                     </div>
                 </section>
 
-                <!-- Section 8: Contact -->
+                <!-- Section 8: Governing Law -->
                 <section>
                     <h2 class="text-xl font-display font-semibold text-white mb-4">
-                        8. Contact
+                        8. Governing Law and Jurisdiction
                     </h2>
                     <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
                         <p>
-                            For questions about these terms, please contact the service administrator.
+                            These Terms of Service are governed by the laws of the Republic of Estonia, without regard to conflict of law principles.
+                        </p>
+                        <p>
+                            Any disputes arising from the use of this service shall be subject to the exclusive jurisdiction of the courts of the Republic of Estonia.
                         </p>
                     </div>
                 </section>
 
-                <!-- Legal References -->
+                <!-- Section 9: Contact -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        9. Contact
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            For questions about these terms, please contact the service administrator at the email address associated with this service.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Legal Framework -->
                 <div class="border-t border-white/[0.04] pt-6">
                     <h3 class="text-sm font-display font-semibold text-gray-500 uppercase tracking-wider mb-3">
-                        Legal Framework
+                        Applicable Legal Framework
                     </h3>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs text-gray-600 font-mono">
                         <div class="bg-surface-800/50 rounded-lg p-3">
@@ -177,18 +204,21 @@
                             <span class="text-gray-500">Estonia:</span> Autoriõiguse seadus
                         </div>
                         <div class="bg-surface-800/50 rounded-lg p-3">
-                            <span class="text-gray-500">Precedent:</span> Cox v. Sony (2026), Yout v. RIAA
+                            <span class="text-gray-500">License:</span> GNU GPLv3 §§15-16
                         </div>
                     </div>
+                </div>
+
+                <!-- Consent -->
+                <div class="border-t border-white/[0.04] pt-6">
+                    <p class="text-xs text-gray-600 font-body">
+                        By using Vooglaadija, you confirm that you have read, understood, and agree to be bound by these Terms of Service. You acknowledge that you are responsible for ensuring any downloads comply with applicable law.
+                    </p>
                 </div>
             </div>
 
             <!-- Footer Navigation -->
-            <div class="mt-8 flex justify-center gap-6">
-                <a href="/privacy" class="text-sm text-gray-500 hover:text-amber-400 transition-colors duration-300">
-                    Privacy Policy
-                </a>
-                <span class="text-gray-700">|</span>
+            <div class="mt-8 flex justify-center">
                 <a href="/web/login" class="text-sm text-gray-500 hover:text-amber-400 transition-colors duration-300">
                     Sign In
                 </a>

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -198,7 +198,7 @@
                             <span class="text-gray-500">US:</span> DMCA §1201, Copyright Law
                         </div>
                         <div class="bg-surface-800/50 rounded-lg p-3">
-                            <span class="text-gray-500">EU:</span> DSA Art. 17, Copyright Directive
+                            <span class="text-gray-500">EU:</span> Copyright Directive Art. 17, DSA
                         </div>
                         <div class="bg-surface-800/50 rounded-lg p-3">
                             <span class="text-gray-500">Estonia:</span> Autoriõiguse seadus

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -18,7 +18,7 @@
                     Terms of Service
                 </h1>
                 <p class="mt-3 text-gray-500 font-body">
-                    Last updated: {{ last_updated }}
+                    Last updated: April 26, 2026
                 </p>
             </div>
 

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -1,0 +1,199 @@
+{% extends "base.html" %}
+
+{% block title %}Terms of Service — Vooglaadija{% endblock %}
+
+{% block nav_actions %}
+<a href="/web/login" class="btn-secondary text-sm">
+    Sign In
+</a>
+{% endblock %}
+
+{% block content %}
+<div class="min-h-[calc(100vh-4rem)] py-12 px-4 sm:px-6 lg:px-8 relative">
+    <div class="max-w-3xl mx-auto relative z-10">
+        <div class="slide-up opacity-0-initial animate-fill-forwards">
+            <!-- Header -->
+            <div class="text-center mb-10">
+                <h1 class="text-3xl font-display font-bold text-white tracking-tight">
+                    Terms of Service
+                </h1>
+                <p class="mt-3 text-gray-500 font-body">
+                    Last updated: {{ current_year }}
+                </p>
+            </div>
+
+            <!-- Terms Card -->
+            <div class="card-glow p-8 space-y-8">
+                <!-- Important Notice -->
+                <div class="bg-amber-500/10 border border-amber-500/20 rounded-xl p-6">
+                    <div class="flex items-start gap-4">
+                        <div class="flex-shrink-0 mt-0.5">
+                            <svg class="h-6 w-6 text-amber-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.374-1.5-4.242 0L3.616 6.376c-.866 1.5.217 3.374 1.948 3.374h1.872zm1.5 0v1.5m0 1.5v1.5m0 1.5v1.5m6-9H9m-6-3h6m-6 0h6m-4.5 0H6m3 0h3m-4.5 0H6m3 0h3" />
+                            </svg>
+                        </div>
+                        <div>
+                            <h3 class="font-display font-semibold text-amber-400 mb-2">
+                                Important Legal Notice
+                            </h3>
+                            <p class="text-sm text-gray-400 leading-relaxed">
+                                <strong class="text-gray-300">You are solely responsible for ensuring you have the right to download any content before using Vooglaadija.</strong>
+                                Downloading copyrighted content without authorization may violate YouTube's Terms of Service, applicable copyright laws, and the DMCA. Vooglaadija is a tool — its presence on this server does not authorize any particular download.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Section 1: Acceptance -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        1. Acceptance of Terms
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            By accessing or using Vooglaadija, you agree to be bound by these Terms of Service. If you do not agree to these terms, do not use this service.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 2: Permitted Uses -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        2. Permitted Uses
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>Vooglaadija is intended for lawful purposes only. Permitted uses include:</p>
+                        <ul class="list-disc list-inside space-y-1.5 ml-4">
+                            <li>Downloading content you own or have created yourself</li>
+                            <li>Downloading content with the explicit permission of the copyright holder</li>
+                            <li>Downloading content licensed under Creative Commons or similar free licenses</li>
+                            <li>Downloading public domain content</li>
+                            <li>Archival or backup purposes with the creator's consent</li>
+                        </ul>
+                    </div>
+                </section>
+
+                <!-- Section 3: Prohibited Uses -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        3. Prohibited Uses
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>You agree not to use Vooglaadija to:</p>
+                        <ul class="list-disc list-inside space-y-1.5 ml-4">
+                            <li>Download content you do not have the right to download</li>
+                            <li>Circumvent any technological protection measures or access controls</li>
+                            <li>Violate YouTube's Terms of Service or any applicable platform terms</li>
+                            <li>Infringe copyright or other intellectual property rights</li>
+                            <li>Redistribute downloaded content without authorization</li>
+                            <li>Use the service for any commercial purpose without proper authorization</li>
+                        </ul>
+                    </div>
+                </section>
+
+                <!-- Section 4: Disclaimer -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        4. Disclaimer of Liability
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            <strong class="text-gray-300">Vooglaadija is provided "AS IS" without warranty of any kind.</strong>
+                            The operators of this service make no representations about the legality of any specific use of this tool. Copyright law varies by jurisdiction. Users are advised to consult qualified legal counsel before downloading any content.
+                        </p>
+                        <p>
+                            To the maximum extent permitted by law, the operators of this service shall not be liable for any damages arising from the use of Vooglaadija, including but not limited to direct, indirect, incidental, special, or consequential damages.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 5: DMCA -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        5. DMCA and Content Removal
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            If you believe that content on YouTube infringes your copyright, please contact YouTube directly or file a DMCA takedown request with YouTube. Vooglaadija operators cannot remove content from YouTube.
+                        </p>
+                        <p>
+                            If you are a rights holder and believe that this service is being used to infringe your rights, contact the service administrator. We take intellectual property rights seriously and will cooperate with legitimate takedown requests.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 6: Nature of Service -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        6. Nature of Vooglaadija
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            Vooglaadija is open-source software distributed under the GNU General Public License v3.0. It is a passive tool — the service operator does not select, modify, or control the content being downloaded. The user initiates all downloads.
+                        </p>
+                        <p>
+                            This service architecture (local file storage, authenticated access, time-limited download links) is designed to limit third-party liability exposure and is not intended to facilitate copyright infringement.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 7: Changes to Terms -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        7. Changes to These Terms
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            These terms may be updated at any time. Continued use of the service after any changes constitutes acceptance of the updated terms.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 8: Contact -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        8. Contact
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            For questions about these terms, please contact the service administrator.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Legal References -->
+                <div class="border-t border-white/[0.04] pt-6">
+                    <h3 class="text-sm font-display font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                        Legal Framework
+                    </h3>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs text-gray-600 font-mono">
+                        <div class="bg-surface-800/50 rounded-lg p-3">
+                            <span class="text-gray-500">US:</span> DMCA §1201, Copyright Law
+                        </div>
+                        <div class="bg-surface-800/50 rounded-lg p-3">
+                            <span class="text-gray-500">EU:</span> DSA Art. 17, Copyright Directive
+                        </div>
+                        <div class="bg-surface-800/50 rounded-lg p-3">
+                            <span class="text-gray-500">Estonia:</span> Autoriõiguse seadus
+                        </div>
+                        <div class="bg-surface-800/50 rounded-lg p-3">
+                            <span class="text-gray-500">Precedent:</span> Cox v. Sony (2026), Yout v. RIAA
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Footer Navigation -->
+            <div class="mt-8 flex justify-center gap-6">
+                <a href="/privacy" class="text-sm text-gray-500 hover:text-amber-400 transition-colors duration-300">
+                    Privacy Policy
+                </a>
+                <span class="text-gray-700">|</span>
+                <a href="/web/login" class="text-sm text-gray-500 hover:text-amber-400 transition-colors duration-300">
+                    Sign In
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -18,7 +18,7 @@
                     Terms of Service
                 </h1>
                 <p class="mt-3 text-gray-500 font-body">
-                    Last updated: {{ current_year }}
+                    Last updated: {{ last_updated }}
                 </p>
             </div>
 
@@ -185,10 +185,6 @@
 
             <!-- Footer Navigation -->
             <div class="mt-8 flex justify-center gap-6">
-                <a href="/privacy" class="text-sm text-gray-500 hover:text-amber-400 transition-colors duration-300">
-                    Privacy Policy
-                </a>
-                <span class="text-gray-700">|</span>
                 <a href="/web/login" class="text-sm text-gray-500 hover:text-amber-400 transition-colors duration-300">
                     Sign In
                 </a>

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -18,7 +18,7 @@
                     Terms of Service
                 </h1>
                 <p class="mt-3 text-gray-500 font-body">
-                    Last updated: April 2026
+                    Last updated: {{ last_updated }}
                 </p>
             </div>
 
@@ -29,7 +29,7 @@
                     <div class="flex items-start gap-4">
                         <div class="flex-shrink-0 mt-0.5">
                             <svg class="h-6 w-6 text-amber-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.374-1.5-4.242 0L3.616 6.376c-.866 1.5.217 3.374 1.948 3.374h1.872zm1.5 0v1.5m0 1.5v1.5m0 1.5v1.5m6-9H9m-6-3h6m-6 0h6m-4.5 0H6m3 0h3m-4.5 0H6m3 0h3" />
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.374-1.5-4.242 0L3.616 6.376c-.866 1.5.217 3.374 1.948 3.374h1.872zM12 15.75h.008v.008H12v-.008z" />
                             </svg>
                         </div>
                         <div>

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -1,0 +1,235 @@
+{% extends "base.html" %}
+
+{% block title %}Terms of Service — Vooglaadija{% endblock %}
+
+{% block nav_actions %}
+<a href="/web/login" class="btn-secondary text-sm">
+    Sign In
+</a>
+{% endblock %}
+
+{% block content %}
+<div class="min-h-[calc(100vh-4rem)] py-12 px-4 sm:px-6 lg:px-8 relative">
+    <div class="max-w-3xl mx-auto relative z-10">
+        <div class="slide-up opacity-0-initial animate-fill-forwards">
+            <!-- Header -->
+            <div class="text-center mb-10">
+                <h1 class="text-3xl font-display font-bold text-white tracking-tight">
+                    Terms of Service
+                </h1>
+                <p class="mt-3 text-gray-500 font-body">
+                    Last updated: {{ last_updated }}
+                </p>
+            </div>
+
+            <!-- Terms Card -->
+            <div class="card-glow p-8 space-y-8">
+                <!-- Important Notice -->
+                <div class="bg-amber-500/10 border border-amber-500/20 rounded-xl p-6">
+                    <div class="flex items-start gap-4">
+                        <div class="flex-shrink-0 mt-0.5">
+                            <svg class="h-6 w-6 text-amber-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.374-1.5-4.242 0L3.616 6.376c-.866 1.5.217 3.374 1.948 3.374h1.872zM12 15.75h.008v.008H12v-.008z" />
+                            </svg>
+                        </div>
+                        <div>
+                            <h3 class="font-display font-semibold text-amber-400 mb-2">
+                                Important Legal Notice
+                            </h3>
+                            <p class="text-sm text-gray-400 leading-relaxed">
+                                <strong class="text-gray-300">You are solely responsible for ensuring you have the right to download any content before using Vooglaadija.</strong>
+                                Downloading copyrighted content without authorization may violate YouTube's Terms of Service, applicable copyright laws, and the DMCA. Vooglaadija is a tool — its presence on this server does not authorize any particular download.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Section 1: Acceptance -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        1. Acceptance of Terms
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            By accessing or using Vooglaadija, you acknowledge that you have read, understood, and agree to be bound by these Terms of Service. If you do not agree to these terms, do not use this service.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 2: Permitted Uses -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        2. Permitted Uses
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>Vooglaadija is intended for lawful purposes only. Permitted uses include:</p>
+                        <ul class="list-disc list-inside space-y-1.5 ml-4">
+                            <li>Downloading content you own or have created yourself</li>
+                            <li>Downloading content with the explicit permission of the copyright holder</li>
+                            <li>Downloading content licensed under Creative Commons or similar free licenses</li>
+                            <li>Downloading public domain content</li>
+                            <li>Archival or backup purposes with the creator's consent</li>
+                        </ul>
+                    </div>
+                </section>
+
+                <!-- Section 3: Prohibited Uses -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        3. Prohibited Uses
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>You agree not to use Vooglaadija to:</p>
+                        <ul class="list-disc list-inside space-y-1.5 ml-4">
+                            <li>Download content you do not have the right to download</li>
+                            <li>Circumvent any technological protection measures or access controls</li>
+                            <li>Violate YouTube's Terms of Service or any applicable platform terms</li>
+                            <li>Infringe copyright or other intellectual property rights</li>
+                            <li>Redistribute downloaded content without authorization</li>
+                            <li>Use the service for any commercial purpose without proper authorization</li>
+                        </ul>
+                    </div>
+                </section>
+
+                <!-- Section 4: Disclaimer -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        4. Disclaimer of Liability
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            <strong class="text-gray-300">Vooglaadija is provided "AS IS" without warranty of any kind.</strong>
+                            The operators of this service make no representations about the legality of any specific use of this tool. Copyright law varies by jurisdiction. Users are advised to consult qualified legal counsel before downloading any content.
+                        </p>
+                        <p>
+                            To the maximum extent permitted by law, the operators of this service shall not be liable for any damages arising from the use of Vooglaadija, including but not limited to direct, indirect, incidental, special, or consequential damages.
+                        </p>
+                        <p>
+                            As permitted by GPLv3 Sections 15 and 16, this software is provided without warranty or liability of any kind for any purpose.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 5: DMCA -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        5. DMCA and Content Removal
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            If you believe that content on YouTube infringes your copyright, please contact YouTube directly or file a DMCA takedown request with YouTube. Vooglaadija operators cannot remove content from YouTube.
+                        </p>
+                        <p>
+                            If you are a rights holder and believe that this service is being used to infringe your rights, contact the service administrator. We take intellectual property rights seriously and will cooperate with legitimate takedown requests.
+                        </p>
+                        <div class="bg-surface-800/50 rounded-lg p-4 mt-4">
+                            <h4 class="text-sm font-display font-semibold text-gray-300 mb-2">DMCA Designated Agent</h4>
+                            <p class="text-xs text-gray-500">
+                                <strong class="text-amber-400">[TODO: Provide the designated agent's name, physical address, telephone number, and email per 17 U.S.C. § 512(c)(2) before deploying to production.]</strong><br />
+                                To file a DMCA takedown request, contact the designated agent at
+                                <span class="font-mono">[agent-email@example.com]</span>
+                                or via the designated takedown form once configured.
+                            </p>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Section 6: Nature of Service -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        6. Nature of Vooglaadija
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            Vooglaadija is open-source software distributed under the GNU General Public License v3.0. It is a passive tool — the service operator does not select, modify, or control the content being downloaded. The user initiates all downloads.
+                        </p>
+                        <p>
+                            This service architecture (local file storage, authenticated access, time-limited download links) is designed to limit third-party liability exposure and is not intended to facilitate copyright infringement.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 7: Changes to Terms -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        7. Changes to These Terms
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            These terms may be updated at any time to reflect changes in law, service architecture, or operational requirements. Material changes will be communicated via a notice on this page and, where practicable, via the service dashboard.
+                        </p>
+                        <p>
+                            Continued use of the service after any modification constitutes acceptance of the updated terms. Users are advised to review these terms periodically.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 8: Governing Law -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        8. Governing Law and Jurisdiction
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            These Terms of Service are governed by the laws of the Republic of Estonia, without regard to conflict of law principles.
+                        </p>
+                        <p>
+                            Any disputes arising from the use of this service shall be subject to the exclusive jurisdiction of the courts of the Republic of Estonia.
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Section 9: Contact -->
+                <section>
+                    <h2 class="text-xl font-display font-semibold text-white mb-4">
+                        9. Contact
+                    </h2>
+                    <div class="text-gray-400 font-body space-y-3 text-sm leading-relaxed">
+                        <p>
+                            For questions about these terms, please contact the designated agent at
+                            <span class="font-mono">[agent-email@example.com]</span>
+                            or via the designated takedown form once configured.
+                            <strong class="text-amber-400">[TODO: Provide the designated agent's name, physical address, telephone number, and email per 17 U.S.C. § 512(c)(2) before deploying to production.]</strong>
+                        </p>
+                    </div>
+                </section>
+
+                <!-- Legal Framework -->
+                <div class="border-t border-white/[0.04] pt-6">
+                    <h3 class="text-sm font-display font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                        Applicable Legal Framework
+                    </h3>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs text-gray-600 font-mono">
+                        <div class="bg-surface-800/50 rounded-lg p-3">
+                            <span class="text-gray-500">US:</span> DMCA §1201, Copyright Law
+                        </div>
+                        <div class="bg-surface-800/50 rounded-lg p-3">
+                            <span class="text-gray-500">EU:</span> Copyright Directive (Dir. (EU) 2019/790) Art. 17; DSA (Reg. (EU) 2022/2065)
+                        </div>
+                        <div class="bg-surface-800/50 rounded-lg p-3">
+                            <span class="text-gray-500">Estonia:</span> Autoriõiguse seadus
+                        </div>
+                        <div class="bg-surface-800/50 rounded-lg p-3">
+                            <span class="text-gray-500">License:</span> GNU GPLv3 §§15-16
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Consent -->
+                <div class="border-t border-white/[0.04] pt-6">
+                    <p class="text-xs text-gray-600 font-body">
+                        By using Vooglaadija, you confirm that you have read, understood, and agree to be bound by these Terms of Service. You acknowledge that you are responsible for ensuring any downloads comply with applicable law.
+                    </p>
+                </div>
+            </div>
+
+            <!-- Footer Navigation -->
+            <div class="mt-8 flex justify-center">
+                <a href="/web/login" class="text-sm text-gray-500 hover:text-amber-400 transition-colors duration-300">
+                    Sign In
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_api/test_web_routes.py
+++ b/tests/test_api/test_web_routes.py
@@ -1736,3 +1736,234 @@ class TestCleanupJobFiles:
 
         assert all_cleaned is False
         assert len(failures) == 1
+
+
+class TestTermsPage:
+    """Tests for the GET /web/terms endpoint added in this PR."""
+
+    async def test_terms_page_returns_200(self):
+        """Terms page should return 200 OK without authentication."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert response.status_code == 200
+
+    async def test_terms_page_sets_csrf_cookie(self):
+        """Terms page should set a csrf_token cookie on the response."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert response.status_code == 200
+        assert response.cookies.get("csrf_token") is not None
+
+    async def test_terms_page_returns_html(self):
+        """Terms page should return HTML content type."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "text/html" in response.headers.get("content-type", "")
+
+    async def test_terms_page_renders_title(self):
+        """Terms page should render the 'Terms of Service' heading."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Terms of Service" in response.text
+
+    async def test_terms_page_renders_acceptance_section(self):
+        """Terms page should include the Acceptance of Terms section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Acceptance of Terms" in response.text
+
+    async def test_terms_page_renders_permitted_uses_section(self):
+        """Terms page should include the Permitted Uses section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Permitted Uses" in response.text
+
+    async def test_terms_page_renders_prohibited_uses_section(self):
+        """Terms page should include the Prohibited Uses section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Prohibited Uses" in response.text
+
+    async def test_terms_page_renders_disclaimer_section(self):
+        """Terms page should include the Disclaimer of Liability section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Disclaimer of Liability" in response.text
+
+    async def test_terms_page_renders_dmca_section(self):
+        """Terms page should include the DMCA and Content Removal section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "DMCA and Content Removal" in response.text
+
+    async def test_terms_page_contains_current_year(self):
+        """Terms page should render current_year from template context."""
+        from datetime import UTC, datetime
+
+        current_year = str(datetime.now(UTC).year)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert current_year in response.text
+
+    async def test_terms_page_csrf_token_in_html_matches_cookie(self):
+        """The CSRF token embedded in the page should match the cookie value."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        csrf_cookie = response.cookies.get("csrf_token")
+        assert csrf_cookie is not None
+        # The CSRF token must appear somewhere in the rendered HTML
+        assert csrf_cookie in response.text
+
+    async def test_terms_page_accessible_without_auth(self):
+        """Terms page must be reachable without any authentication headers."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            # Explicitly no auth headers
+            response = await client.get("/web/terms", headers={})
+
+        # Should not redirect to login
+        assert response.status_code == 200
+
+    async def test_terms_page_has_sign_in_link(self):
+        """Terms page footer navigation should contain a Sign In link."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "/web/login" in response.text
+
+    async def test_terms_page_has_privacy_link(self):
+        """Terms page footer navigation should contain a Privacy Policy link."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "/privacy" in response.text
+
+    async def test_terms_page_important_legal_notice_present(self):
+        """Terms page should render the Important Legal Notice warning box."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Important Legal Notice" in response.text
+
+    async def test_terms_page_nature_of_service_section(self):
+        """Terms page should include the Nature of Vooglaadija section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Nature of Vooglaadija" in response.text
+
+    async def test_terms_page_new_csrf_token_each_request(self):
+        """Each request to /web/terms should set a CSRF cookie (may differ per request)."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response1 = await client.get("/web/terms")
+            csrf1 = response1.cookies.get("csrf_token")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response2 = await client.get("/web/terms")
+            csrf2 = response2.cookies.get("csrf_token")
+
+        # Both requests must receive a CSRF token (values may or may not differ)
+        assert csrf1 is not None
+        assert csrf2 is not None
+
+    async def test_terms_page_existing_csrf_cookie_reused(self):
+        """When a csrf_token cookie is sent with the request, the same token is reused."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            # First request: obtain a fresh CSRF token
+            first = await client.get("/web/terms")
+            existing_token = first.cookies.get("csrf_token")
+            assert existing_token is not None
+
+            # Second request within the same client so the cookie jar carries the token
+            second = await client.get("/web/terms")
+
+        returned_token = second.cookies.get("csrf_token")
+        # The server should honour the pre-existing cookie and return the same value
+        assert returned_token == existing_token

--- a/tests/test_api/test_web_routes.py
+++ b/tests/test_api/test_web_routes.py
@@ -3679,3 +3679,270 @@ class TestResolveErrorsHelpers:
         message, field_errors = _resolve_settings_errors("unknown_code")
         assert message is None
         assert field_errors == {}
+
+
+class TestTermsPage:
+    """Tests for the GET /web/terms endpoint added in this PR."""
+
+    async def test_terms_page_returns_200(self):
+        """Terms page should return 200 OK without authentication."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert response.status_code == 200
+
+    async def test_terms_page_sets_csrf_cookie(self):
+        """Terms page should set a csrf_token cookie on the response."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert response.status_code == 200
+        assert response.cookies.get("csrf_token") is not None
+
+    async def test_terms_page_returns_html(self):
+        """Terms page should return HTML content type."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "text/html" in response.headers.get("content-type", "")
+
+    async def test_terms_page_renders_title(self):
+        """Terms page should render the 'Terms of Service' heading."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Terms of Service" in response.text
+
+    async def test_terms_page_renders_acceptance_section(self):
+        """Terms page should include the Acceptance of Terms section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Acceptance of Terms" in response.text
+
+    async def test_terms_page_renders_permitted_uses_section(self):
+        """Terms page should include the Permitted Uses section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Permitted Uses" in response.text
+
+    async def test_terms_page_renders_prohibited_uses_section(self):
+        """Terms page should include the Prohibited Uses section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Prohibited Uses" in response.text
+
+    async def test_terms_page_renders_disclaimer_section(self):
+        """Terms page should include the Disclaimer of Liability section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Disclaimer of Liability" in response.text
+
+    async def test_terms_page_renders_dmca_section(self):
+        """Terms page should include the DMCA and Content Removal section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "DMCA and Content Removal" in response.text
+
+    async def test_terms_page_contains_current_year(self):
+        """Terms page footer should render the current year as a whole token (e.g. '© 2026')."""
+        from datetime import UTC, datetime
+
+        # Match the app: get_template_context uses datetime.now(UTC).year.
+        current_year = str(datetime.now(UTC).year)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        # Anchor to the copyright entity so a bare 4-digit number appearing
+        # elsewhere in the page (the last_updated date, statute refs, etc.)
+        # cannot cause a false pass. The template emits the literal HTML entity
+        # "&copy;", which is preserved verbatim in the raw response body.
+        assert f"&copy; {current_year}" in response.text
+
+    async def test_terms_page_csrf_token_in_html_matches_cookie(self):
+        """The CSRF token embedded in the page should match the cookie value."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        csrf_cookie = response.cookies.get("csrf_token")
+        assert csrf_cookie is not None
+        # The CSRF token must appear somewhere in the rendered HTML
+        assert csrf_cookie in response.text
+
+    async def test_terms_page_accessible_without_auth(self):
+        """Terms page must be reachable without any authentication headers."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            # Explicitly no auth headers
+            response = await client.get("/web/terms", headers={})
+
+        # Should not redirect to login
+        assert response.status_code == 200
+
+    async def test_terms_page_has_sign_in_link(self):
+        """Terms page footer navigation should contain a Sign In link."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "/web/login" in response.text
+
+    async def test_terms_page_has_terms_link(self):
+        """Terms page footer navigation should contain a link back to /web/terms."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "/web/terms" in response.text
+
+    async def test_terms_page_renders_dmca_agent_placeholder(self):
+        """DMCA designated agent section must flag that statutory contact details are missing."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "DMCA Designated Agent" in response.text
+        # Statutory § 512(c)(2) contact details must be explicitly called out as TODO.
+        assert "512(c)(2)" in response.text
+
+    async def test_terms_page_renders_explicit_last_updated(self):
+        """The 'Last updated' date must be an explicit revision date, not the auto year."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Last updated: April 26, 2026" in response.text
+
+    async def test_terms_page_important_legal_notice_present(self):
+        """Terms page should render the Important Legal Notice warning box."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Important Legal Notice" in response.text
+
+    async def test_terms_page_nature_of_service_section(self):
+        """Terms page should include the Nature of Vooglaadija section."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/web/terms")
+
+        assert "Nature of Vooglaadija" in response.text
+
+    async def test_terms_page_new_csrf_token_each_request(self):
+        """Each request to /web/terms should set a CSRF cookie (may differ per request)."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response1 = await client.get("/web/terms")
+            csrf1 = response1.cookies.get("csrf_token")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            response2 = await client.get("/web/terms")
+            csrf2 = response2.cookies.get("csrf_token")
+
+        # Both requests must receive a CSRF token (values may or may not differ)
+        assert csrf1 is not None
+        assert csrf2 is not None
+
+    async def test_terms_page_existing_csrf_cookie_reused(self):
+        """When a csrf_token cookie is sent with the request, the same token is reused."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            # First request: obtain a fresh CSRF token
+            first = await client.get("/web/terms")
+            existing_token = first.cookies.get("csrf_token")
+            assert existing_token is not None
+
+            # Second request within the same client so the cookie jar carries the token
+            second = await client.get("/web/terms")
+
+            # Read the cookie jar while the client is still open (httpx does not
+            # guarantee jar state after the context manager exits).
+            jar_token = client.cookies.get("csrf_token")
+            second_html = second.text
+
+        # response.cookies only reflects Set-Cookie headers; the authoritative source
+        # for "reuse" is the client's cookie jar (and the token embedded in the HTML).
+        assert jar_token == existing_token
+        # The rendered page must embed the same, reused token.
+        assert existing_token in second_html


### PR DESCRIPTION
- Create /web/terms route in web.py with full ToS page
- Add terms.html template with:
  - Prominent legal warning about user responsibility
  - Permitted/prohibited uses sections
  - DMCA notice and contact info
  - Legal framework references (Cox v Sony, Yout v RIAA)
- Update README.md with:
  - Legitimate use cases section
  - Legal disclaimer about copyright/DMCA compliance
  - Link to full Terms of Service
- Fix base.html footer links to use /web/terms
- Add NOTICE file for GPL compliance with third-party attributions
- Add DMCA §1201 notice emphasizing substantial non-infringing uses