### PR TITLE
docs(readme): add live demo badge linking to production instance

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,7 +164,7 @@
         "filename": "README.md",
         "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 149
       }
     ],
     "alembic.ini": [
@@ -674,5 +674,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-22T18:22:44Z"
+  "generated_at": "2026-06-24T02:30:22Z"
 }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ _Pronounced voo-gla-tee-ya_ — Media Link Processor
 
 Async video media extraction API with job queue and real-time status streaming.
 
+[![Live Demo](https://img.shields.io/badge/Live%20Demo-youtube.tomabel.ee-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://youtube.tomabel.ee)
+
 [![Python](https://img.shields.io/badge/Python-3.12+-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
 [![License](https://img.shields.io/badge/License-GPLv3-A41E35?style=for-the-badge&logo=gnu&logoColor=white)](https://www.gnu.org/licenses/gpl-3.0.html)
 [![Version](https://img.shields.io/badge/Version-1.0.0-22D3EE?style=for-the-badge)](https://github.com/tomkabel/team21-vooglaadija)


### PR DESCRIPTION
## Summary

Adds a prominent **Live Demo** badge to the top of `README.md`, linking directly to the production instance at `https://youtube.tomabel.ee`.

## Change Details

- **Badge style:** shields.io `for-the-badge` (matches existing tech-stack badges)
- **Color:** `#FF0000` (YouTube red) — thematically tied to the project's YouTube media extraction purpose and high-contrast against surrounding badges
- **Icon:** White YouTube play icon (`logo=youtube&logoColor=white`)
- **Label:** `LIVE DEMO | YOUTUBE.TOMABEL.EE`
- **Placement:** Directly below the project description and above the existing tech-stack badge row, creating a clear visual hierarchy and call-to-action

## Rationale

Following the GitHub standard used by projects such as n8n, Meilisearch, and Uptime Kuma, a dedicated live-demo badge separates the "try it now" CTA from build/status badges so visitors immediately know where to go to see the project in action.

## Verification

- [x] Badge renders correctly at shields.io
- [x] Target URL (`youtube.tomabel.ee`) resolves and loads the Vooglaadija login page
- [x] Markdown syntax is valid
- [x] Placement preserves existing README layout

## Checklist

- [x] I have read the project's contributing guidelines
- [x] This is a documentation-only change with no runtime impact
- [x] Pre-commit hooks pass